### PR TITLE
When creating new file ObjectId will be returned. Also added optional kw...

### DIFF
--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -337,3 +337,7 @@ class PyMongo(object):
 
         storage = GridFS(self.db, base)
         return storage.put(fileobj, filename=filename, content_type=content_type)
+
+    def delete_file(self, file_id, base='fs'):
+        storage = GridFS(self.db, base)
+        storage.delete(file_id)

--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -259,7 +259,7 @@ class PyMongo(object):
         return current_app.extensions['pymongo'][self.config_prefix][1]
 
     # view helpers
-    def send_file(self, filename, base='fs', version=-1, cache_for=31536000):
+    def send_file(self, filename, base='fs', version=-1, cache_for=31536000, **kwargs):
         """Return an instance of the :attr:`~flask.Flask.response_class`
         containing the named file, and implement conditional GET semantics
         (using :meth:`~werkzeug.wrappers.ETagResponseMixin.make_conditional`).
@@ -288,7 +288,7 @@ class PyMongo(object):
         storage = GridFS(self.db, base)
 
         try:
-            fileobj = storage.get_version(filename=filename, version=version)
+            fileobj = storage.get_version(filename=filename, version=version, **kwargs)
         except NoFile:
             abort(404)
 
@@ -311,7 +311,7 @@ class PyMongo(object):
 
     def save_file(self, filename, fileobj, base='fs', content_type=None):
         """Save the file-like object to GridFS using the given filename.
-        Returns ``None``.
+        Returns file ``ObjectId``.
 
         .. code-block:: python
 
@@ -336,4 +336,4 @@ class PyMongo(object):
             content_type, _ = guess_type(filename)
 
         storage = GridFS(self.db, base)
-        storage.put(fileobj, filename=filename, content_type=content_type)
+        return storage.put(fileobj, filename=filename, content_type=content_type)

--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -310,7 +310,7 @@ class PyMongo(object):
         response.make_conditional(request)
         return response
 
-    def save_file(self, fileobj, base='fs', content_type=None):
+    def save_file(self, fileobj, base='fs', content_type=None, **kwargs):
         """Save the file-like object to GridFS using the given filename.
         Returns file ``ObjectId``.
 
@@ -336,7 +336,7 @@ class PyMongo(object):
             content_type, _ = guess_type(fileobj.filename)
 
         storage = GridFS(self.db, base)
-        return storage.put(fileobj, filename=fileobj.filename, content_type=content_type)
+        return storage.put(fileobj, filename=fileobj.filename, content_type=content_type, **kwargs)
 
     def delete_file(self, file_id, base='fs'):
         storage = GridFS(self.db, base)

--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -299,7 +299,7 @@ class PyMongo(object):
         response = current_app.response_class(
             data,
             mimetype=fileobj.content_type,
-            attachment_filename=fileobj.filename,
+            headers={'Content-Disposition': 'attachment; filename=' + fileobj.filename},
             direct_passthrough=True)
         response.content_length = fileobj.length
         response.last_modified = fileobj.upload_date


### PR DESCRIPTION
It wasn't possible to send_file to client for example by ObjectId and save_file didn't return newly create file ObjectId.
This is very minor change (in compatibility, but major in functionality).