### PR TITLE
Ensure error is raised when URI database name is parsed as 'None'.

### DIFF
--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -128,7 +128,7 @@ class PyMongo(object):
         if key('URI') in app.config:
             # bootstrap configuration from the URL
             parsed = uri_parser.parse_uri(app.config[key('URI')])
-            if 'database' not in parsed:
+            if 'database' not in parsed or not parsed['database']:
                 raise ValueError('MongoDB URI does not contain database name')
             app.config[key('DBNAME')] = parsed['database']
             app.config[key('READ_PREFERENCE')] = parsed['options'].get('read_preference')


### PR DESCRIPTION
You get a rather cryptic error when the `MONGO_URI` config value is missing a database path because `uri_parser.parse_uri(app.config[key'URI'])` returns `{…, "database": None, …}` and `PyMongo.init_app(…)` only checks for the non-existence of the `"database"` key.

This patch fixes that.