### PR TITLE
update requirements for pymongo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Flask >= 0.8
-PyMongo >= 2.4,<=2.7
+PyMongo >= 2.4,<3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Flask >= 0.8
-PyMongo >= 2.4
+PyMongo >= 2.4,<=2.7


### PR DESCRIPTION
Since the 3.0 version of pymongo has broke the tests due to many backward compatibilty breaks, the fastest solution till all the corrections are in place is to force the pymongo version to 2.7 max
