### PR TITLE
Modifications to enable pymongo 3.0.x compatability.

### DIFF
--- a/examples/wiki/wiki.py
+++ b/examples/wiki/wiki.py
@@ -44,7 +44,7 @@ def save_page(pagepath):
         mongo.db.pages.update(
             {'_id': pagepath},
             {'$set': {'body': request.form['body']}},
-            safe=True, upsert=True)
+            w=1, upsert=True)
     return redirect(url_for('show_page', pagepath=pagepath))
 
 @app.errorhandler(404)

--- a/flask_pymongo/wrappers.py
+++ b/flask_pymongo/wrappers.py
@@ -42,6 +42,12 @@ class MongoClient(mongo_client.MongoClient):
             return Database(self, name)
         return attr
 
+    def __getitem__(self, item):
+        attr = super(MongoClient, self).__getitem__(item)
+        if isinstance(attr, database.Database):
+            return Database(self, item)
+        return attr
+
 class MongoReplicaSetClient(mongo_replica_set_client.MongoReplicaSetClient):
     """Returns instances of :class:`flask_pymongo.wrappers.Database`
     instead of :class:`pymongo.database.Database` when accessed with dot
@@ -52,6 +58,12 @@ class MongoReplicaSetClient(mongo_replica_set_client.MongoReplicaSetClient):
         if isinstance(attr, database.Database):
             return Database(self, name)
         return attr
+
+    def __getitem__(self, item):
+        item_ = super(MongoReplicaSetClient, self).__getitem__(item)
+        if isinstance(item_, database.Database):
+            return Database(self, item)
+        return item_
 
 class Database(database.Database):
     """Returns instances of :class:`flask_pymongo.wrappers.Collection`
@@ -65,6 +77,12 @@ class Database(database.Database):
             return Collection(self, name)
         return attr
 
+    def __getitem__(self, item):
+        item_ = super(Database, self).__getitem__(item)
+        if isinstance(item_, collection.Collection):
+            return Collection(self, item)
+        return item_
+
 class Collection(collection.Collection):
     """Custom sub-class of :class:`pymongo.collection.Collection` which
     adds Flask-specific helper methods.
@@ -76,6 +94,13 @@ class Collection(collection.Collection):
             db = self._Collection__database
             return Collection(db, attr.name)
         return attr
+
+    def __getitem__(self, item):
+        item_ = super(Collection, self).__getitem__(item)
+        if isinstance(item_, collection.Collection):
+            db = self._Collection__database
+            return Collection(db, item_.name)
+        return item_
 
     def find_one_or_404(self, *args, **kwargs):
         """Find and return a single document, or raise a 404 Not Found

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Flask >= 0.8
-PyMongo >= 2.4,<3.0
+PyMongo >= 2.4

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,8 @@
 from tests import util
 
+import time
+
+import pymongo
 import flask
 import flask.ext.pymongo
 import warnings
@@ -10,7 +13,6 @@ class CustomDict(dict):
 
 
 class FlaskPyMongoConfigTest(util.FlaskRequestTest):
-
     def setUp(self):
         self.app = flask.Flask('test')
         self.context = self.app.test_request_context('/')
@@ -26,8 +28,12 @@ class FlaskPyMongoConfigTest(util.FlaskRequestTest):
 
         mongo = flask.ext.pymongo.PyMongo(self.app)
         assert mongo.db.name == 'flask_pymongo_test_db', 'wrong dbname: %s' % mongo.db.name
-        assert mongo.cx.host == 'localhost'
-        assert mongo.cx.port == 27017
+        if pymongo.version_tuple[0] > 2:
+            time.sleep(0.2)
+            assert ('localhost', 27017) == mongo.cx.address
+        else:
+            assert mongo.cx.host == 'localhost'
+            assert mongo.cx.port == 27017
 
     def test_custom_config_prefix(self):
         self.app.config['CUSTOM_DBNAME'] = 'flask_pymongo_test_db'
@@ -36,8 +42,12 @@ class FlaskPyMongoConfigTest(util.FlaskRequestTest):
 
         mongo = flask.ext.pymongo.PyMongo(self.app, 'CUSTOM')
         assert mongo.db.name == 'flask_pymongo_test_db', 'wrong dbname: %s' % mongo.db.name
-        assert mongo.cx.host == 'localhost'
-        assert mongo.cx.port == 27017
+        if pymongo.version_tuple[0] > 2:
+            time.sleep(0.2)
+            assert ('localhost', 27017) == mongo.cx.address
+        else:
+            assert mongo.cx.host == 'localhost'
+            assert mongo.cx.port == 27017
 
     def test_converts_str_to_int(self):
         self.app.config['MONGO_DBNAME'] = 'flask_pymongo_test_db'
@@ -46,8 +56,12 @@ class FlaskPyMongoConfigTest(util.FlaskRequestTest):
 
         mongo = flask.ext.pymongo.PyMongo(self.app)
         assert mongo.db.name == 'flask_pymongo_test_db', 'wrong dbname: %s' % mongo.db.name
-        assert mongo.cx.host == 'localhost'
-        assert mongo.cx.port == 27017
+        if pymongo.version_tuple[0] > 2:
+            time.sleep(0.2)
+            assert ('localhost', 27017) == mongo.cx.address
+        else:
+            assert mongo.cx.host == 'localhost'
+            assert mongo.cx.port == 27017
 
     def test_rejects_invalid_string(self):
         self.app.config['MONGO_PORT'] = '27017x'
@@ -61,7 +75,7 @@ class FlaskPyMongoConfigTest(util.FlaskRequestTest):
         for prefix in ('ONE', 'TWO'):
             flask.ext.pymongo.PyMongo(self.app, config_prefix=prefix)
 
-        # this test passes if it raises no exceptions
+            # this test passes if it raises no exceptions
 
     def test_config_with_uri(self):
         self.app.config['MONGO_URI'] = 'mongodb://localhost:27017/flask_pymongo_test_db'
@@ -72,8 +86,12 @@ class FlaskPyMongoConfigTest(util.FlaskRequestTest):
             warnings.simplefilter('ignore')
             mongo = flask.ext.pymongo.PyMongo(self.app)
         assert mongo.db.name == 'flask_pymongo_test_db', 'wrong dbname: %s' % mongo.db.name
-        assert mongo.cx.host == 'localhost'
-        assert mongo.cx.port == 27017
+        if pymongo.version_tuple[0] > 2:
+            time.sleep(0.2)
+            assert ('localhost', 27017) == mongo.cx.address
+        else:
+            assert mongo.cx.host == 'localhost'
+            assert mongo.cx.port == 27017
 
     def test_config_with_uri_no_port(self):
         self.app.config['MONGO_URI'] = 'mongodb://localhost/flask_pymongo_test_db'
@@ -84,17 +102,27 @@ class FlaskPyMongoConfigTest(util.FlaskRequestTest):
             warnings.simplefilter('ignore')
             mongo = flask.ext.pymongo.PyMongo(self.app)
         assert mongo.db.name == 'flask_pymongo_test_db', 'wrong dbname: %s' % mongo.db.name
-        assert mongo.cx.host == 'localhost'
-        assert mongo.cx.port == 27017
+        if pymongo.version_tuple[0] > 2:
+            time.sleep(0.2)
+            assert ('localhost', 27017) == mongo.cx.address
+        else:
+            assert mongo.cx.host == 'localhost'
+            assert mongo.cx.port == 27017
 
     def test_config_with_document_class(self):
         self.app.config['MONGO_DOCUMENT_CLASS'] = CustomDict
         mongo = flask.ext.pymongo.PyMongo(self.app)
-        assert mongo.cx.document_class == CustomDict
+        if pymongo.version_tuple[0] > 2:
+            assert mongo.cx.codec_options.document_class == CustomDict
+        else:
+            assert mongo.cx.document_class == CustomDict
 
     def test_config_without_document_class(self):
         mongo = flask.ext.pymongo.PyMongo(self.app)
-        assert mongo.cx.document_class == dict
+        if pymongo.version_tuple[0] > 2:
+            assert mongo.cx.codec_options.document_class == dict
+        else:
+            assert mongo.cx.document_class == dict
 
     def test_host_with_port_does_not_get_overridden_by_separate_port_config_value(self):
         self.app.config['MONGO_HOST'] = 'localhost:27017'
@@ -105,8 +133,12 @@ class FlaskPyMongoConfigTest(util.FlaskRequestTest):
             # work, but warn that auth should be supplied
             warnings.simplefilter('ignore')
             mongo = flask.ext.pymongo.PyMongo(self.app)
-        assert mongo.cx.host == 'localhost'
-        assert mongo.cx.port == 27017
+        if pymongo.version_tuple[0] > 2:
+            time.sleep(0.2)
+            assert ('localhost', 27017) == mongo.cx.address
+        else:
+            assert mongo.cx.host == 'localhost'
+            assert mongo.cx.port == 27017
 
     def test_uri_prioritised_over_host_and_port(self):
         self.app.config['MONGO_URI'] = 'mongodb://localhost:27017/database_name'
@@ -119,8 +151,12 @@ class FlaskPyMongoConfigTest(util.FlaskRequestTest):
             # work, but warn that auth should be supplied
             warnings.simplefilter('ignore')
             mongo = flask.ext.pymongo.PyMongo(self.app)
-        assert mongo.cx.host == 'localhost'
-        assert mongo.cx.port == 27017
+        if pymongo.version_tuple[0] > 2:
+            time.sleep(0.2)
+            assert ('localhost', 27017) == mongo.cx.address
+        else:
+            assert mongo.cx.host == 'localhost'
+            assert mongo.cx.port == 27017
         assert mongo.db.name == 'database_name'
 
     def test_uri_without_database_errors_sensibly(self):
@@ -130,6 +166,7 @@ class FlaskPyMongoConfigTest(util.FlaskRequestTest):
 
 class CustomDocumentClassTest(util.FlaskPyMongoTest):
     """ Class that tests reading from DB with custom document_class """
+
     def test_create_with_document_class(self):
         """ This test doesn't use self.mongo, because it has to change config
 
@@ -144,14 +181,22 @@ class CustomDocumentClassTest(util.FlaskPyMongoTest):
         # not using self.mongo, because we want to use updated config
         # also using CUSTOM, to avoid duplicate config_prefix exception
         mongo = flask.ext.pymongo.PyMongo(self.app, 'CUSTOM')
-        assert mongo.db.things.find_one() == None
+        assert mongo.db.things.find_one() is None
         # write document and retrieve, to check if type is really CustomDict
-        mongo.db.things.insert({'_id': 'thing', 'val': 'foo'}, safe=True)
+        if pymongo.version_tuple[0] > 2:
+            # Write Concern is set to w=1 by default in pymongo > 3.0
+            mongo.db.things.insert_one({'_id': 'thing', 'val': 'foo'})
+        else:
+            mongo.db.things.insert({'_id': 'thing', 'val': 'foo'}, w=1)
         assert type(mongo.db.things.find_one()) == CustomDict
 
     def test_create_without_document_class(self):
         """ This uses self.mongo, which uses config without document_class """
-        assert self.mongo.db.things.find_one() == None
+        assert self.mongo.db.things.find_one() is None
         # write document and retrieve, to check if type is dict (default)
-        self.mongo.db.things.insert({'_id': 'thing', 'val': 'foo'}, safe=True)
+        if pymongo.version_tuple[0] > 2:
+            # Write Concern is set to w=1 by default in pymongo > 3.0
+            self.mongo.db.things.insert_one({'_id': 'thing', 'val': 'foo'})
+        else:
+            self.mongo.db.things.insert({'_id': 'thing', 'val': 'foo'}, w=1)
         assert type(self.mongo.db.things.find_one()) == dict

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1,6 +1,8 @@
 from tests import util
 from werkzeug.exceptions import HTTPException
 
+import pymongo
+
 class CollectionTest(util.FlaskPyMongoTest):
 
     def test_find_one_or_404(self):
@@ -11,12 +13,14 @@ class CollectionTest(util.FlaskPyMongoTest):
         except HTTPException as notfound:
             assert notfound.code == 404, "raised wrong exception"
 
-        self.mongo.db.things.insert({'_id': 'thing', 'val': 'foo'}, safe=True)
+        if pymongo.version_tuple[0] > 2:
+            self.mongo.db.things.insert_one({'_id': 'thing', 'val': 'foo'})
+        else:
+            self.mongo.db.things.insert({'_id': 'thing', 'val': 'foo'}, w=1)
 
         # now it should not raise
         thing = self.mongo.db.things.find_one_or_404({'_id': 'thing'})
         assert thing['val'] == 'foo', 'got wrong thing'
-
 
         # also test with dotted-named collections
         self.mongo.db.things.morethings.remove()
@@ -25,7 +29,11 @@ class CollectionTest(util.FlaskPyMongoTest):
         except HTTPException as notfound:
             assert notfound.code == 404, "raised wrong exception"
 
-        self.mongo.db.things.morethings.insert({'_id': 'thing', 'val': 'foo'}, safe=True)
+        if pymongo.version_tuple[0] > 2:
+            # Write Concern is set to w=1 by default in pymongo > 3.0
+            self.mongo.db.things.morethings.insert_one({'_id': 'thing', 'val': 'foo'})
+        else:
+            self.mongo.db.things.morethings.insert({'_id': 'thing', 'val': 'foo'}, w=1)
 
         # now it should not raise
         thing = self.mongo.db.things.morethings.find_one_or_404({'_id': 'thing'})


### PR DESCRIPTION
This pull request is an attempt of enabling the use of pymongo >= 3.0.

In `__init__.py` and the test files there are explicit tests whether pymongo >= 3.0 is used, which is ugly, but I have deemed it necessary to bridge the deprecation problems.

Modifications:
* Removed `auto_start_request` from __init__ in the pymongo >= 3.0 case.

* Using only the `MongoClient` for pymongo >= 3.0 case, since `MongoReplicaSetClient` is labelled deprecated and all functionality has been merged to `MongoClient`.

* Wrappers has a overriding `__getitem__` method added. In pymongo < 3.0 the `__getitem__` method (used when calling `c[db_name]`) called the `__getattr__` method (used when calling `c.db_name`), so wrappers did not need to override both then. In pymongo > 3.0 this is not the case and both have to be overridden.

* Tests in `test_config.py` use `mongo.cx.address` property instead of `host` and `port` properties of the `MongoClient` in the pymongo >= 3.0 case, since they have been removed. All tests using this property also sleeps a short time since the client needs some time to establish connection to MongoDB and set the proper values, otherwise the tests fails.

* The `safe` keyword is deprecated for `insert` and `update` methods, though only flagged in pymongo 2.x. Change all these to `w=1` which has equal effect. `insert` method also has a deprecation warning in pymongo 3.0.x, so `insert_one` is used instead in these cases.