### PR TITLE
Added MONGO_CONNECT option at app init.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -108,6 +108,13 @@ directives:
                              the string names thereof
 ``MONGO_DOCUMENT_CLASS``     This tells pymongo to return custom objects instead
                              of dicts, for example ``bson.son.SON``. Default: ``dict``
+``MONGO_CONNECT``            (optional): If ``True`` (the default),
+                             let the MongoClient immediately begin connecting
+                             to MongoDB in the background. Otherwise connect
+                             on the first operation. This has to be set to
+                             ``False`` if multiprocessing is desired; see
+                             `Using PyMongo with Multiprocessing
+                             <https://api.mongodb.org/python/current/faq.html#multiprocessing>`_.
 ============================ ===================================================
 
 When :class:`~flask_pymongo.PyMongo` or

--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -141,6 +141,8 @@ class PyMongo(object):
 
             if pymongo.version_tuple[0] < 3:
                 app.config[key('AUTO_START_REQUEST')] = parsed['options'].get('auto_start_request', True)
+            else:
+                app.config[key('CONNECT')] = parsed['options'].get('connect', True)
 
             # we will use the URI for connecting instead of HOST/PORT
             app.config.pop(key('HOST'), None)
@@ -157,6 +159,8 @@ class PyMongo(object):
 
             if pymongo.version_tuple[0] < 3:
                 app.config.setdefault(key('AUTO_START_REQUEST'), True)
+            else:
+                app.config.setdefault(key('CONNECT'), True)
 
             # these don't have defaults
             app.config.setdefault(key('USERNAME'), None)
@@ -214,6 +218,8 @@ class PyMongo(object):
         }
         if pymongo.version_tuple[0] < 3:
             kwargs['auto_start_request'] = auto_start_request
+        else:
+            kwargs['connect'] = app.config[key('CONNECT')]
 
         if read_preference is not None:
             kwargs['read_preference'] = read_preference


### PR DESCRIPTION
Fixes #66

When using PyMongo >= 3.0 in a [multiprocessing](https://api.mongodb.org/python/current/faq.html#multiprocessing) setup, one might have to initialize the MongoClient with `connect=False` keyword. This pull requests adds such a setting.