### PR TITLE
Delete __init__.py in tests directory

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,4 @@
-from tests import util
+from util import FlaskRequestTest, FlaskPyMongoTest
 
 import time
 
@@ -12,7 +12,7 @@ class CustomDict(dict):
     pass
 
 
-class FlaskPyMongoConfigTest(util.FlaskRequestTest):
+class FlaskPyMongoConfigTest(FlaskRequestTest):
     def setUp(self):
         self.app = flask.Flask('test')
         self.context = self.app.test_request_context('/')
@@ -164,7 +164,7 @@ class FlaskPyMongoConfigTest(util.FlaskRequestTest):
         self.assertRaises(ValueError, flask.ext.pymongo.PyMongo, self.app)
 
 
-class CustomDocumentClassTest(util.FlaskPyMongoTest):
+class CustomDocumentClassTest(FlaskPyMongoTest):
     """ Class that tests reading from DB with custom document_class """
 
     def test_create_with_document_class(self):

--- a/tests/test_url_converter.py
+++ b/tests/test_url_converter.py
@@ -1,10 +1,10 @@
-from tests import util
+from util import FlaskPyMongoTest
 from flask.ext.pymongo import BSONObjectIdConverter
 
 from bson import ObjectId
 from werkzeug.exceptions import BadRequest
 
-class UrlConverterTest(util.FlaskPyMongoTest):
+class UrlConverterTest(FlaskPyMongoTest):
 
     def test_bson_object_id_converter(self):
         converter = BSONObjectIdConverter("/")

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1,9 +1,9 @@
-from tests import util
+from util import FlaskPyMongoTest
 from werkzeug.exceptions import HTTPException
 
 import pymongo
 
-class CollectionTest(util.FlaskPyMongoTest):
+class CollectionTest(FlaskPyMongoTest):
 
     def test_find_one_or_404(self):
         self.mongo.db.things.remove()


### PR DESCRIPTION
When trying to install this module in a global namespace, 'tests' is installed as a separate module that conflicts with other packages (if they have the same problem).

There are different ways to avoid this, but I'm trying the easy approach, and sending a pull request to see if the tests will still run in travis.