### PR TITLE
Added connect keyword support for mongo_client

### DIFF
--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -171,6 +171,12 @@ class PyMongo(object):
 
             host = app.config[key('HOST')]
 
+        app.config.setdefault(key('CONNECT'), '1')
+        if app.config[key('CONNECT')].lower() in ('false', 'f', '0'):
+            app.config[key('CONNECT')] = False
+        else:
+            app.config[key('CONNECT')] = True
+
         username = app.config[key('USERNAME')]
         password = app.config[key('PASSWORD')]
 
@@ -211,6 +217,7 @@ class PyMongo(object):
         kwargs = {
             'port': int(app.config[key('PORT')]),
             'tz_aware': True,
+            'connect': app.config[key('CONNECT')]
         }
         if pymongo.version_tuple[0] < 3:
             kwargs['auto_start_request'] = auto_start_request


### PR DESCRIPTION
connect keyword tells client to connect immediately to the server. Set to False to allow for multithreading so the client won’t connect until needed. Use configuration keyword PREFIX_CONNECT which defaults to True. 