### PR TITLE
Add missing requiremt gridfs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask >= 0.8
 PyMongo >= 2.4
+gridfs


### PR DESCRIPTION
It is used in imports flask_pymongo/__init__.py:32