### PR TITLE
Max_pool_size renamed maxPoolSize in pymongo>=3.0

### DIFF
--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -241,7 +241,10 @@ class PyMongo(object):
             connection_cls = MongoClient
 
         if max_pool_size is not None:
-            kwargs['max_pool_size'] = max_pool_size
+            if pymongo.version_tuple[0] < 3:
+                kwargs['max_pool_size'] = max_pool_size
+            else:
+                kwargs['maxPoolSize'] = max_pool_size
 
         if document_class is not None:
             kwargs['document_class'] = document_class


### PR DESCRIPTION
I actually happened to make what I believe is a fix for #77 yesterday: In PyMongo>=3.0, the parameter max_pool_size is renamed maxPoolSize, which will lead to that very problem.

I was making some modifications to fit another issue and did this as well.
