### PR TITLE
Using configuration variables values in conjunction with URI values

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -74,7 +74,9 @@ directives:
 ``MONGO_URI``                A `MongoDB URI
                              <http://www.mongodb.org/display/DOCS/Connections#Connections-StandardConnectionStringFormat>`_
                              which is used in preference of the other
-                             configuration variables.
+                             configuration variables. For those parameters not
+                             specified in the URI, configuration variables
+                             are used if present.
 ``MONGO_HOST``               The host name or IP address of your MongoDB server.
                              Default: "localhost".
 ``MONGO_PORT``               The port number of your MongoDB server. Default:

--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -131,18 +131,44 @@ class PyMongo(object):
             if not parsed.get('database'):
                 raise ValueError('MongoDB URI does not contain database name')
             app.config[key('DBNAME')] = parsed['database']
-            app.config[key('READ_PREFERENCE')] = parsed['options'].get('read_preference')
-            app.config[key('USERNAME')] = parsed['username']
-            app.config[key('PASSWORD')] = parsed['password']
-            app.config[key('REPLICA_SET')] = parsed['options'].get('replica_set')
-            app.config[key('MAX_POOL_SIZE')] = parsed['options'].get('max_pool_size')
-            app.config[key('SOCKET_TIMEOUT_MS')] = parsed['options'].get('socket_timeout_ms', None)
-            app.config[key('CONNECT_TIMEOUT_MS')] = parsed['options'].get('connect_timeout_ms', None)
+
+            # Set these parameters if they are provided in URI. If not,
+            # let them be uninitialized so that config variables will be used
+            # instead if they are present.
+            if parsed['options'].get('read_preference'):
+                app.config[key('READ_PREFERENCE')] = parsed['options'].get('read_preference')
+            app.config.setdefault(key('READ_PREFERENCE'), None)
+
+            if parsed['username'] is not None:
+                app.config[key('USERNAME')] = parsed['username']
+            app.config.setdefault(key('USERNAME'), None)
+
+            if parsed['password'] is not None:
+                app.config[key('PASSWORD')] = parsed['password']
+            app.config.setdefault(key('PASSWORD'), None)
+
+            if parsed['options'].get('replica_set') is not None:
+                app.config[key('REPLICA_SET')] = parsed['options'].get('replica_set')
+            app.config.setdefault(key('REPLICA_SET'), None)
+
+            if parsed['options'].get('max_pool_size') is not None:
+                app.config[key('MAX_POOL_SIZE')] = parsed['options'].get('max_pool_size')
+            app.config.setdefault(key('MAX_POOL_SIZE'), None)
+
+            if parsed['options'].get('socket_timeout_ms') is not None:
+                app.config[key('SOCKET_TIMEOUT_MS')] = parsed['options'].get('socket_timeout_ms')
+            app.config.setdefault(key('SOCKET_TIMEOUT_MS'), None)
+
+            if parsed['options'].get('connect_timeout_ms') is not None:
+                app.config[key('CONNECT_TIMEOUT_MS')] = parsed['options'].get('connect_timeout_ms')
+            app.config.setdefault(key('CONNECT_TIMEOUT_MS'), None)
 
             if pymongo.version_tuple[0] < 3:
-                app.config[key('AUTO_START_REQUEST')] = parsed['options'].get('auto_start_request', True)
+                app.config[key('AUTO_START_REQUEST')] = parsed['options'].get('auto_start_request')
             else:
-                app.config[key('CONNECT')] = parsed['options'].get('connect', True)
+                if parsed['options'].get('connect') is not None:
+                    app.config[key('CONNECT')] = parsed['options'].get('connect')
+                app.config.setdefault(key('CONNECT'), True)
 
             # we will use the URI for connecting instead of HOST/PORT
             app.config.pop(key('HOST'), None)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -159,6 +159,36 @@ class FlaskPyMongoConfigTest(FlaskRequestTest):
             assert mongo.cx.port == 27017
         assert mongo.db.name == 'database_name'
 
+    def test_uri_priorities(self):
+        self.app.config['MONGO_URI'] = 'mongodb://localhost:27017/database_name?connect=false'
+        self.app.config['MONGO_CONNECT'] = True
+
+        with warnings.catch_warnings():
+            # URI connections without a username and password
+            # work, but warn that auth should be supplied
+            warnings.simplefilter('ignore')
+            mongo = flask.ext.pymongo.PyMongo(self.app)
+        if pymongo.version_tuple[0] > 2:
+            time.sleep(0.2)
+            assert "connect=False" in repr(mongo.cx)
+        else:
+            assert True
+
+    def test_uri_fallback_to_parameters(self):
+        self.app.config['MONGO_URI'] = 'mongodb://localhost:27017/database_name'
+        self.app.config['MONGO_CONNECT'] = False
+
+        with warnings.catch_warnings():
+            # URI connections without a username and password
+            # work, but warn that auth should be supplied
+            warnings.simplefilter('ignore')
+            mongo = flask.ext.pymongo.PyMongo(self.app)
+        if pymongo.version_tuple[0] > 2:
+            time.sleep(0.2)
+            assert "connect=False" in repr(mongo.cx)
+        else:
+            assert True
+
     def test_uri_without_database_errors_sensibly(self):
         self.app.config['MONGO_URI'] = 'mongodb://localhost:27017/'
         self.assertRaises(ValueError, flask.ext.pymongo.PyMongo, self.app)


### PR DESCRIPTION
Fixes issue #73.

Configuration values were ignored when using a Mongo URI. This PR adds a fallback to configuration values if the parameter is not set in the URI.
