### PR TITLE
issue #84 Importing flask.ext.pymongo is deprecated, use flask_pymongo instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ PyMongo support for Flask applications
 ## Quickstart
 
     from flask import Flask
-    from flask.ext.pymongo import PyMongo
+    from flask_pymongo import PyMongo
 
     app = Flask(__name__)
     mongo = PyMongo(app)

--- a/examples/wiki/wiki.py
+++ b/examples/wiki/wiki.py
@@ -1,5 +1,5 @@
 from flask import Flask, redirect, render_template, request, url_for
-from flask.ext.pymongo import PyMongo
+from flask_pymongo import PyMongo
 import markdown2
 import re
 


### PR DESCRIPTION
updated example and quickstart in readme to import with flask_pymongo instead. 