### PR TITLE
Adding support for auth source and auth mechanism

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -96,6 +96,7 @@ directives:
                              attribute. Default: ``app.name``.
 ``MONGO_USERNAME``           The user name for authentication. Default: ``None``
 ``MONGO_PASSWORD``           The password for authentication. Default: ``None``
+``MONGO_AUTH_SOURCE``        The database to authenticate against. Default: ``None``
 ``MONGO_REPLICA_SET``        The name of a replica set to connect to; this must
                              match the internal name of the replica set (as
                              deteremined by the `isMaster

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -97,6 +97,8 @@ directives:
 ``MONGO_USERNAME``           The user name for authentication. Default: ``None``
 ``MONGO_PASSWORD``           The password for authentication. Default: ``None``
 ``MONGO_AUTH_SOURCE``        The database to authenticate against. Default: ``None``
+``MONGO_AUTH_MECHANISM``     The mechanism to authenticate with.
+                             Default: pymongo <3.x ``MONGODB-CR`` else ``SCRAM-SHA-1``
 ``MONGO_REPLICA_SET``        The name of a replica set to connect to; this must
                              match the internal name of the replica set (as
                              deteremined by the `isMaster

--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -143,10 +143,10 @@ class PyMongo(object):
 
             if pymongo.version_tuple[0] < 3:
                 app.config[key('AUTO_START_REQUEST')] = parsed['options'].get('auto_start_request', True)
-                app.config[(key('AUTH_MECHANISM')] = 'MONGODB-CR'
+                app.config[key('AUTH_MECHANISM')] = 'MONGODB-CR'
             else:
                 app.config[key('CONNECT')] = parsed['options'].get('connect', True)
-                app.config[(key('AUTH_MECHANISM')] = 'SCRAM-SHA-1'
+                app.config[key('AUTH_MECHANISM')] = 'SCRAM-SHA-1'
 
             # we will use the URI for connecting instead of HOST/PORT
             app.config.pop(key('HOST'), None)

--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -182,8 +182,6 @@ class PyMongo(object):
 
         auth = (username, password)
 
-        auth_source = app.config[key('AUTH_SOURCE')]
-
         if any(auth) and not all(auth):
             raise Exception('Must set both USERNAME and PASSWORD or neither')
 
@@ -254,6 +252,7 @@ class PyMongo(object):
         db = cx[dbname]
 
         if any(auth):
+            auth_source = app.config[key('AUTH_SOURCE')]
             db.authenticate(username, password, source = auth_source)
 
         app.extensions['pymongo'][config_prefix] = (cx, db)

--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -102,11 +102,11 @@ class PyMongo(object):
 
         The app is configured according to the configuration variables
         ``PREFIX_HOST``, ``PREFIX_PORT``, ``PREFIX_DBNAME``,
-        ``PREFIX_AUTO_START_REQUEST``,
-        ``PREFIX_REPLICA_SET``, ``PREFIX_READ_PREFERENCE``,
-        ``PREFIX_USERNAME``, ``PREFIX_PASSWORD``, and ``PREFIX_URI`` where
-        "PREFIX" defaults to "MONGO". If ``PREFIX_URL`` is set, it is
-        assumed to have all appropriate configurations, and the other
+        ``PREFIX_AUTO_START_REQUEST``, ``PREFIX_REPLICA_SET``,
+        ``PREFIX_READ_PREFERENCE``, ``PREFIX_USERNAME``,
+        ``PREFIX_PASSWORD``, ``PREFXI_AUTH_SOURCE``, and ``PREFIX_URI``
+        where "PREFIX" defaults to "MONGO". If ``PREFIX_URL`` is set, it
+        is assumed to have all appropriate configurations, and the other
         keys are overwritten using their values as present in the URI.
 
         :param flask.Flask app: the application to configure for use with
@@ -134,6 +134,7 @@ class PyMongo(object):
             app.config[key('READ_PREFERENCE')] = parsed['options'].get('read_preference')
             app.config[key('USERNAME')] = parsed['username']
             app.config[key('PASSWORD')] = parsed['password']
+            app.config[key('AUTH_SOURCE')] = parsed['options'].get('authsource', None)
             app.config[key('REPLICA_SET')] = parsed['options'].get('replica_set')
             app.config[key('MAX_POOL_SIZE')] = parsed['options'].get('max_pool_size')
             app.config[key('SOCKET_TIMEOUT_MS')] = parsed['options'].get('socket_timeout_ms', None)
@@ -165,6 +166,7 @@ class PyMongo(object):
             # these don't have defaults
             app.config.setdefault(key('USERNAME'), None)
             app.config.setdefault(key('PASSWORD'), None)
+            app.config.setdefault(key('AUTH_SOURCE'), None)
             app.config.setdefault(key('REPLICA_SET'), None)
             app.config.setdefault(key('MAX_POOL_SIZE'), None)
 
@@ -179,6 +181,8 @@ class PyMongo(object):
         password = app.config[key('PASSWORD')]
 
         auth = (username, password)
+
+        auth_source = app.config[key('AUTH_SOURCE')]
 
         if any(auth) and not all(auth):
             raise Exception('Must set both USERNAME and PASSWORD or neither')
@@ -250,7 +254,7 @@ class PyMongo(object):
         db = cx[dbname]
 
         if any(auth):
-            db.authenticate(username, password)
+            db.authenticate(username, password, source = auth_source)
 
         app.extensions['pymongo'][config_prefix] = (cx, db)
         app.url_map.converters['ObjectId'] = BSONObjectIdConverter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Flask >= 0.8
-PyMongo >= 2.4
+PyMongo >= 2.5


### PR DESCRIPTION
This is a follow up to #36 to hopefully close out #34 

I think this would also necessitate a version bump to flask-pymongo but will let the maintainer make that decision