### PR TITLE
Default AUTH_MECHANISM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,4 @@ services: mongodb
 install: pip install -r test-requirements.txt -e .
 script: py.test --tb=native tests
 before_script:
-  - mongod --version
   - mongo test_db --eval 'db.addUser("flask", "pymongo");'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ python:
 services: mongodb
 install: pip install -r test-requirements.txt -e .
 script: py.test --tb=native tests
+before_script:
+  - mongod --version
+  - mongo test_db --eval 'db.addUser("flask", "pymongo");'

--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -184,7 +184,6 @@ class PyMongo(object):
             app.config.setdefault(key('AUTH_SOURCE'), None)
             app.config.setdefault(key('REPLICA_SET'), None)
             app.config.setdefault(key('MAX_POOL_SIZE'), None)
-
             app.config.setdefault(key('AUTH_MECHANISM'), 'DEFAULT')
 
             try:

--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -185,6 +185,8 @@ class PyMongo(object):
             app.config.setdefault(key('REPLICA_SET'), None)
             app.config.setdefault(key('MAX_POOL_SIZE'), None)
 
+            app.config.setdefault(key('AUTH_MECHANISM'), 'DEFAULT')
+
             try:
                 int(app.config[key('PORT')])
             except ValueError:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -160,6 +160,29 @@ class FlaskPyMongoConfigTest(FlaskRequestTest):
         assert mongo.db.name == 'database_name'
 
 
+    def test_missing_auth_mechanism_in_prefixed_config(self):
+
+        self.app.config["CUSTOM_MONGO_HOST"] = 'localhost'
+        self.app.config["CUSTOM_MONGO_PORT"] = 27017
+        self.app.config["CUSTOM_MONGO_USERNAME"] = 'flask'
+        self.app.config["CUSTOM_MONGO_PASSWORD"] = 'pymongo'
+        self.app.config['CUSTOM_MONGO_DBNAME'] = 'test_db'
+
+        mongo = flask_pymongo.PyMongo(self.app, 'CUSTOM_MONGO')
+
+        assert mongo.db.name == 'test_db', 'wrong dbname: %s' % mongo.db.name
+
+        if pymongo.version_tuple[0] > 2:
+            time.sleep(0.2)
+
+            assert ('localhost', 27017) == mongo.cx.address
+        else:
+            assert mongo.cx.host == 'localhost'
+            assert mongo.cx.port == 27017
+
+
+
+
 class CustomDocumentClassTest(FlaskPyMongoTest):
     """ Class that tests reading from DB with custom document_class """
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -160,6 +160,27 @@ class FlaskPyMongoConfigTest(FlaskRequestTest):
         assert mongo.db.name == 'database_name'
 
 
+    def test_missing_auth_mechanism_in_nonprefixed_config(self):
+
+        self.app.config["MONGO_HOST"] = 'localhost'
+        self.app.config["MONGO_PORT"] = 27017
+        self.app.config["MONGO_USERNAME"] = 'flask'
+        self.app.config["MONGO_PASSWORD"] = 'pymongo'
+        self.app.config['MONGO_DBNAME'] = 'test_db'
+
+        mongo = flask_pymongo.PyMongo(self.app)
+
+        assert mongo.db.name == 'test_db', 'wrong dbname: %s' % mongo.db.name
+
+        if pymongo.version_tuple[0] > 2:
+            time.sleep(0.2)
+
+            assert ('localhost', 27017) == mongo.cx.address
+        else:
+            assert mongo.cx.host == 'localhost'
+            assert mongo.cx.port == 27017
+
+
     def test_missing_auth_mechanism_in_prefixed_config(self):
 
         self.app.config["CUSTOM_MONGO_HOST"] = 'localhost'


### PR DESCRIPTION
Sets default AUTH_MECHANISM values when using non URI configuration method.

Without this, trying to configure pymongo using a configuration prefix causes a KeyError

(Now with added tests)