### PR TITLE
according to the docs, this should be a 404

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ _build
 .coverage
 dist
 *.pyc
+.pytest_cache/
 
 .idea

--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -81,7 +81,7 @@ class BSONObjectIdConverter(BaseConverter):
         try:
             return ObjectId(value)
         except InvalidId:
-            raise abort(400)
+            raise abort(404)
 
     def to_url(self, value):
         return str(value)

--- a/tests/test_url_converter.py
+++ b/tests/test_url_converter.py
@@ -2,14 +2,14 @@ from util import FlaskPyMongoTest
 from flask_pymongo import BSONObjectIdConverter
 
 from bson import ObjectId
-from werkzeug.exceptions import BadRequest
+from werkzeug.exceptions import NotFound
 
 class UrlConverterTest(FlaskPyMongoTest):
 
     def test_bson_object_id_converter(self):
         converter = BSONObjectIdConverter("/")
 
-        self.assertRaises(BadRequest, converter.to_python, ("132"))
+        self.assertRaises(NotFound, converter.to_python, ("132"))
         assert converter.to_python("4e4ac5cfffc84958fa1f45fb") == \
                ObjectId("4e4ac5cfffc84958fa1f45fb")
         assert converter.to_url(ObjectId("4e4ac5cfffc84958fa1f45fb")) == \


### PR DESCRIPTION
http://flask-pymongo.readthedocs.io/en/latest/#flask_pymongo.BSONObjectIdConverter

Moreover, I think it's more consistent to return a 404 than a 400 in such situation.