### PR TITLE
Fix #108 issue where providing URI overwrites options with defaults

### DIFF
--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -133,27 +133,27 @@ class PyMongo(object):
             if parsed.get('database') is not None:
                 auth_database = parsed['database']
 
-            app.config[key('DBNAME')] = parsed.get('database') or app.name
+            app.config[key('DBNAME')] = parsed.get('database', app.config.get(key('DBNAME'), app.name))
             app.config[key('READ_PREFERENCE')] = parsed['options'].get('readpreference')
-            app.config[key('USERNAME')] = parsed['username']
-            app.config[key('PASSWORD')] = parsed['password']
-            app.config[key('AUTH_SOURCE')] = parsed['options'].get('authsource', None)
-            app.config[key('AUTH_MECHANISM')] = parsed['options'].get('authmechanism', None)
-            app.config[key('REPLICA_SET')] = parsed['options'].get('replicaset')
-            app.config[key('MAX_POOL_SIZE')] = parsed['options'].get('maxpoolsize')
-            app.config[key('SOCKET_TIMEOUT_MS')] = parsed['options'].get('sockettimeoutms', None)
-            app.config[key('CONNECT_TIMEOUT_MS')] = parsed['options'].get('connecttimeoutms', None)
-            app.config[key('SERVER_SELECTION_TIMEOUT_MS')] = parsed['options'].get('serverselectiontimeoutms', None)
+            app.config[key('USERNAME')] = parsed.get('username', app.config.get(key('USERNAME'), None))
+            app.config[key('PASSWORD')] = parsed.get('password', app.config.get(key('PASSWORD')))
+            app.config[key('AUTH_SOURCE')] = parsed['options'].get('authsource', app.config.get(key('AUTH_SOURCE')))
+            app.config[key('AUTH_MECHANISM')] = parsed['options'].get('authmechanism', app.config.get(key('AUTH_MECHANISM')))
+            app.config[key('REPLICA_SET')] = parsed['options'].get('replicaset', app.config.get(key('REPLICA_SET')))
+            app.config[key('MAX_POOL_SIZE')] = parsed['options'].get('maxpoolsize', app.config.get(key('MAX_POOL_SIZE')))
+            app.config[key('SOCKET_TIMEOUT_MS')] = parsed['options'].get('sockettimeoutms', app.config.get(key('SOCKET_TIMEOUT_MS')))
+            app.config[key('CONNECT_TIMEOUT_MS')] = parsed['options'].get('connecttimeoutms', app.config.get(key('CONNECT_TIMEOUT_MS')))
+            app.config[key('SERVER_SELECTION_TIMEOUT_MS')] = parsed['options'].get('serverselectiontimeoutms', app.config.get(key('SERVER_SELECTION_TIMEOUT_MS')))
 
             if pymongo.version_tuple[0] < 3:
-                app.config[key('AUTO_START_REQUEST')] = parsed['options'].get('auto_start_request', True)
+                app.config[key('AUTO_START_REQUEST')] = parsed['options'].get('auto_start_request', app.config.get(key('AUTO_START_REQUEST'), True))
                 app.config[key('AUTH_MECHANISM')] = 'MONGODB-CR'
             else:
-                app.config[key('CONNECT')] = parsed['options'].get('connect', True)
+                app.config[key('CONNECT')] = parsed['options'].get('connect', app.config.get(key('CONNECT'), True))
                 app.config[key('AUTH_MECHANISM')] = 'SCRAM-SHA-1'
 
                 if parsed['options'].get('server_selection_timeout_ms') is not None:
-                    app.config[key('SERVER_SELECTION_TIMEOUT_MS')] = parsed['options'].get('server_selection_timeout_ms')
+                    app.config[key('SERVER_SELECTION_TIMEOUT_MS')] = parsed['options'].get('server_selection_timeout_ms', app.config.get(key('SERVER_SELECTION_TIMEOUT_MS')))
                 app.config.setdefault(key('SERVER_SELECTION_TIMEOUT_MS'), None)
 
             # we will use the URI for connecting instead of HOST/PORT


### PR DESCRIPTION
Fixes the issue of providing URI option overwrites options with default values when the options
are not provided in the URI itself but set as individual settings. When you set 'MONGO_CONNECT', for
exmaple, to 'False' but you didn't provide the 'connect' option in the URI, it will overwrite
'MONGO_CONNET' with 'True' even thought it's set