### PR TITLE
Fix broken flask extension interface.

### DIFF
--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -108,7 +108,7 @@ class PyMongo(object):
 
     """
 
-    def __init__(self, app, uri=None, *args, **kwargs):
+    def __init__(self, app=None, uri=None, *args, **kwargs):
         self.cx = None
         self.db = None
 


### PR DESCRIPTION
According to http://flask.pocoo.org/docs/1.0/extensiondev/

> The `__init__` method takes an optional app object and, if supplied, will
call `init_app`.

