### PR TITLE
Fix quickstart example

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ PyMongo support for Flask applications
 ## Quickstart
 
 ```python
-from flask import Flask
+from flask import Flask, render_template
 from flask_pymongo import PyMongo
 
 app = Flask(__name__)


### PR DESCRIPTION
If someone run the quickstart sample equal to the example, will be fail, because render_template is not imported.