### PR TITLE
test matrix: added mongo 4.2, pymongo 3.9, flask 1.1; removed flask 0.11, python 3.4

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,8 +17,6 @@ jobs:
     matrix:
       Python27:
         python.version: '2.7'
-      Python34:
-        python.version: '3.4'
       Python35:
         python.version: '3.5'
       Python36:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,7 +65,7 @@ versions.
 
 Flask-PyMongo is tested against `supported versions
 <https://www.mongodb.com/support-policy>`_ of MongoDB, and Python 2.7
-and 3.4+. For the exact list of version combinations that are tested and
+and 3.5+. For the exact list of version combinations that are tested and
 known to be compatible, see the `envlist` in `tox.ini
 <https://github.com/dcrosta/flask-pymongo/blob/master/tox.ini>`_.
 
@@ -190,6 +190,9 @@ Changes:
     quickstart example in README (Emmanuel Arias).
   - `#62 <https://github.com/dcrosta/flask-pymongo/issues/62>`_ Add
     support for :func:`~flask.json.jsonify()`.
+  - `#131 <https://github.com/dcrosta/flask-pymongo/pulls/131>`_ Drop
+    support for Flask 0.11 and Python 3.4; Add support for MongoDB 4.2,
+    PyMongo 3.9, and Flask 1.1.
 
 - 2.3.0: April 24, 2019
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     platforms="any",
     packages=find_packages(),
     install_requires=[
-        "Flask>=0.11",
+        "Flask>=0.12",
         "PyMongo>=3.3",
         "six",
     ],
@@ -41,10 +41,9 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
         "Topic :: Software Development :: Libraries :: Python Modules"

--- a/tox.ini
+++ b/tox.ini
@@ -2,14 +2,14 @@
 
 ; keep the pymongo list in sync with what's in .travis.yaml
 envlist=
-    pymongo{33,34,35,36,37,38}-mongo{34,36,40,41}-flask{0_11,0_12,10}, style
+    pymongo{33,34,35,36,37,38,39}-mongo{34,36,40,42}-flask{0_12,10,11}, style
 
 [testenv]
 docker =
     mongo34: mongo:3.4
     mongo36: mongo:3.6
     mongo40: mongo:4.0
-    mongo41: mongo:4.1
+    mongo42: mongo:4.2
 
 deps =
     pytest
@@ -20,10 +20,11 @@ deps =
     pymongo36: pymongo>=3.6,<3.7
     pymongo37: pymongo>=3.7,<3.8
     pymongo38: pymongo>=3.8,<3.9
+    pymongo39: pymongo>=3.9,<3.10
 
-    flask0_11: flask>=0.11,<0.12
     flask0_12: flask>=0.12,<1.0
     flask10:   flask>=1.0,<1.1
+    flask11:   flask>=1.1,<1.2
 
 commands =
     {envbindir}/py.test --tb=native {toxinidir}


### PR DESCRIPTION
Eventually this will close #127; but we'll wait until the official 4.2 series is released (currently it's in RC) and available in Docker hub.