### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -94,7 +94,7 @@ You can configure Flask-PyMongo either by passing a `MongoDB URI
 ``MONGO_URI`` `Flask configuration variable
 <http://flask.pocoo.org/docs/1.0/config/>`_
 
-The :class:`~flask_pymongo.PyMongo` instnace also accepts these additional
+The :class:`~flask_pymongo.PyMongo` instance also accepts these additional
 customization options:
 
 * ``json_options``, a :class:`~bson.json_util.JSONOptions` instance which
@@ -306,7 +306,7 @@ Changes:
   - This is a minor version bump which introduces backwards breaking
     changes! Please read these change notes carefully.
   - Removed read preference constants from Flask-PyMongo; to set a
-    read preference, use the string name or import contants directly
+    read preference, use the string name or import constants directly
     from :class:`pymongo.read_preferences.ReadPreference`.
   - `#22 (partial) <https://github.com/dcrosta/flask-pymongo/pull/22>`_
     Add support for ``MONGO_SOCKET_TIMEOUT_MS`` and

--- a/flask_pymongo/helpers.py
+++ b/flask_pymongo/helpers.py
@@ -69,7 +69,7 @@ class BSONObjectIdConverter(BaseConverter):
 
     The :class:`~flask_pymongo.helpers.BSONObjectIdConverter` is
     automatically installed on the :class:`~flask_pymongo.PyMongo`
-    instnace at creation time.
+    instance at creation time.
 
     """
 
@@ -135,7 +135,7 @@ class JSONEncoder(flask_json.JSONEncoder):
 
         Falls back to Flask's default JSON serialization for all other types.
 
-        This may raise ``TypeError`` for object types not recignozed.
+        This may raise ``TypeError`` for object types not recognized.
 
         .. versionadded:: 2.4.0
 


### PR DESCRIPTION
There are small typos in:
- docs/index.rst
- flask_pymongo/helpers.py

Fixes:
- Should read `instance` rather than `instnace`.
- Should read `recognized` rather than `recignozed`.
- Should read `constants` rather than `contants`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md