### PR TITLE
Black formatter

### DIFF
--- a/flask_pymongo/__init__.py
+++ b/flask_pymongo/__init__.py
@@ -197,5 +197,7 @@ class PyMongo(object):
             content_type, _ = guess_type(filename)
 
         storage = GridFS(self.db, base)
-        id = storage.put(fileobj, filename=filename, content_type=content_type, **kwargs)
+        id = storage.put(
+            fileobj, filename=filename, content_type=content_type, **kwargs
+        )
         return id

--- a/flask_pymongo/helpers.py
+++ b/flask_pymongo/helpers.py
@@ -36,6 +36,7 @@ import pymongo
 
 if pymongo.version_tuple >= (3, 5, 0):
     from bson.json_util import RELAXED_JSON_OPTIONS
+
     DEFAULT_JSON_OPTIONS = RELAXED_JSON_OPTIONS
 else:
     DEFAULT_JSON_OPTIONS = None

--- a/flask_pymongo/tests/test_config.py
+++ b/flask_pymongo/tests/test_config.py
@@ -21,7 +21,6 @@ def doesnt_raise(exc=BaseException):
 
 
 class FlaskPyMongoConfigTest(FlaskRequestTest):
-
     def setUp(self):
         super(FlaskPyMongoConfigTest, self).setUp()
 

--- a/flask_pymongo/tests/test_gridfs.py
+++ b/flask_pymongo/tests/test_gridfs.py
@@ -10,7 +10,6 @@ from flask_pymongo.tests.util import FlaskPyMongoTest
 
 
 class GridFSCleanupMixin(object):
-
     def tearDown(self):
         gridfs = GridFS(self.mongo.db)
         files = list(gridfs.find())
@@ -21,7 +20,6 @@ class GridFSCleanupMixin(object):
 
 
 class TestSaveFile(GridFSCleanupMixin, FlaskPyMongoTest):
-
     def test_it_saves_files(self):
         fileobj = BytesIO(b"these are the bytes")
 
@@ -57,7 +55,6 @@ class TestSaveFile(GridFSCleanupMixin, FlaskPyMongoTest):
 
 
 class TestSendFile(GridFSCleanupMixin, FlaskPyMongoTest):
-
     def setUp(self):
         super(TestSendFile, self).setUp()
 

--- a/flask_pymongo/tests/test_json.py
+++ b/flask_pymongo/tests/test_json.py
@@ -8,7 +8,6 @@ from flask_pymongo.tests.util import FlaskPyMongoTest
 
 
 class JSONTest(FlaskPyMongoTest):
-
     def test_it_encodes_json(self):
         resp = jsonify({"foo": "bar"})
         dumped = json.loads(ensure_str(resp.get_data()))

--- a/flask_pymongo/tests/test_url_converter.py
+++ b/flask_pymongo/tests/test_url_converter.py
@@ -6,12 +6,14 @@ from flask_pymongo.tests.util import FlaskPyMongoTest
 
 
 class UrlConverterTest(FlaskPyMongoTest):
-
     def test_bson_object_id_converter(self):
         converter = BSONObjectIdConverter("/")
 
         self.assertRaises(NotFound, converter.to_python, ("132"))
-        assert converter.to_python("4e4ac5cfffc84958fa1f45fb") == \
-            ObjectId("4e4ac5cfffc84958fa1f45fb")
-        assert converter.to_url(ObjectId("4e4ac5cfffc84958fa1f45fb")) == \
+        assert converter.to_python("4e4ac5cfffc84958fa1f45fb") == ObjectId(
             "4e4ac5cfffc84958fa1f45fb"
+        )
+        assert (
+            converter.to_url(ObjectId("4e4ac5cfffc84958fa1f45fb"))
+            == "4e4ac5cfffc84958fa1f45fb"
+        )

--- a/flask_pymongo/tests/test_wrappers.py
+++ b/flask_pymongo/tests/test_wrappers.py
@@ -4,7 +4,6 @@ from flask_pymongo.tests.util import FlaskPyMongoTest
 
 
 class CollectionTest(FlaskPyMongoTest):
-
     def test_find_one_or_404(self):
         self.mongo.db.things.delete_many({})
 

--- a/flask_pymongo/tests/util.py
+++ b/flask_pymongo/tests/util.py
@@ -34,7 +34,6 @@ class ToxDockerMixin(object):
 
 
 class FlaskRequestTest(ToxDockerMixin, unittest.TestCase):
-
     def setUp(self):
         super(FlaskRequestTest, self).setUp()
 
@@ -50,7 +49,6 @@ class FlaskRequestTest(ToxDockerMixin, unittest.TestCase):
 
 
 class FlaskPyMongoTest(FlaskRequestTest):
-
     def setUp(self):
         super(FlaskPyMongoTest, self).setUp()
 

--- a/flask_pymongo/wrappers.py
+++ b/flask_pymongo/wrappers.py
@@ -77,9 +77,7 @@ class Database(database.Database):
 
 class Collection(collection.Collection):
 
-    """Sub-class of PyMongo :class:`~pymongo.collection.Collection` with helpers.
-
-    """
+    """Sub-class of PyMongo :class:`~pymongo.collection.Collection` with helpers."""
 
     def __getattr__(self, name):  # noqa: D105
         attr = super(Collection, self).__getattr__(name)

--- a/tox.ini
+++ b/tox.ini
@@ -34,10 +34,10 @@ skip_install = true
 deps =
     flake8
     flake8-quotes
-    flake8-commas
-    https://github.com/dcrosta/flake8-import-order/archive/add-fromsfirst-style.tar.gz#egg=flake8-import-order
+    black
 
 commands =
+    black {toxinidir}/flask_pymongo
     flake8 [] {toxinidir}/flask_pymongo
 
 [flake8]
@@ -46,7 +46,7 @@ inline-quotes = double
 max-complexity = 7
 max-line-length = 90
 import-order-style = fromsfirst
-ignore = D100,D104,D107
+ignore = D100,D104,D107,W503
 exclude =
     _version.py
 


### PR DESCRIPTION
Hello, @dcrosta!

I understand, it's may be too late for this PR, but I've found this library and I made a little project with it. I found this repo a little bit outdated, so I've decided to contribute.

I added black support in tox's env 'style', as you mentioned in issue https://github.com/dcrosta/flask-pymongo/issues/128
You said you want to keep your flake8 imports plugin ordering, but black
currently support the way it is already.
flake8 had only one conflict with current black: W503 rule, so I added it to ignore.

p.s. this is my first PR, so if you have something to fix up here, let me know!
p.p.s. If you don't mind, may be I can do next issue with mypy?
p.p.p.s. pymongo's current version 4.1.1, may be we can update flask_pymongo to support this version as well?
